### PR TITLE
Corrects code to handle nil values and applies Rubocop standards

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 ruby '2.5.1'
 
-gem "sinatra"
-gem "haml", ">= 5.0.0"
-
+gem 'haml', '>= 5.0.0'
+gem 'rubocop'
+gem 'sinatra'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,32 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.1)
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt
     mustermann (1.0.3)
+    parallel (1.20.1)
+    parser (3.0.0.0)
+      ast (~> 2.4.1)
     rack (2.0.7)
     rack-protection (2.0.5)
       rack
+    rainbow (3.0.0)
+    regexp_parser (2.0.3)
+    rexml (3.2.4)
+    rubocop (1.7.0)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.5)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.2.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (1.4.0)
+      parser (>= 2.7.1.5)
+    ruby-progressbar (1.11.0)
     sinatra (2.0.5)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -15,12 +34,14 @@ GEM
       tilt (~> 2.0)
     temple (0.8.1)
     tilt (2.0.9)
+    unicode-display_width (1.7.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   haml (>= 5.0.0)
+  rubocop
   sinatra
 
 RUBY VERSION

--- a/compare.rb
+++ b/compare.rb
@@ -11,7 +11,7 @@ def getJSON(url)
     JSON.parse(json)
 end
 
-def getOwnedGames(person) 
+def getOwnedGames(person)
     url = "http://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/?key=#{@steam_key}&steamid=#{person}&format=json"
     getJSON(url)
 end
@@ -47,7 +47,11 @@ end
 sharedGamesIds = greenGames & laggyGames
 sharedGames = Array.new
 sharedGamesIds.each do |g|
+  if appHash[g].nil?
+    next
+  else
     sharedGames << appHash[g]
+  end
 end
 sharedGames.sort!
 

--- a/compare.rb
+++ b/compare.rb
@@ -6,58 +6,56 @@ require 'net/http'
 @laggy = 76561197970651383
 @steam_key = ENV['STEAM_API_KEY']
 
-def getJSON(url)
-    json = Net::HTTP.get(URI.parse(url))
-    JSON.parse(json)
+def pull_json(url)
+  json = Net::HTTP.get(URI.parse(url))
+  JSON.parse(json)
 end
 
-def getOwnedGames(person)
-    url = "http://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/?key=#{@steam_key}&steamid=#{person}&format=json"
-    getJSON(url)
+def pull_owned_games(person)
+  url = "http://api.steampowered.com/IPlayerService/GetOwnedGames/
+         v0001/?key=#{@steam_key}&steamid=#{person}&format=json"
+  pull_json(url)
 end
 
-def getAppList
-    url = "http://api.steampowered.com/ISteamApps/GetAppList/v0001/"
-    getJSON(url)
+def pull_app_list
+  url = 'http://api.steampowered.com/ISteamApps/GetAppList/v0001/'
+  pull_json(url)
 end
 
 # get id to name map
-appHash = Hash.new
-appList = getAppList
-appList["applist"]["apps"]["app"].each do |a|
-    appHash[a["appid"]] = a["name"]
+app_hash = {}
+app_list = pull_app_list
+app_list['applist']['apps']['app'].each do |a|
+  app_hash[a['appid']] = a['name']
 end
 
-
 # get green's games
-greenGamesRaw = getOwnedGames(@green)["response"]["games"]
-greenGames = Array.new
-greenGamesRaw.each do |g|
-    greenGames << g["appid"]
+green_games_raw = pull_owned_games(@green)['response']['games']
+green_games = []
+green_games_raw.each do |g|
+  green_games << g['appid']
 end
 
 # get laggy's games
-laggyGamesRaw = getOwnedGames(@laggy)["response"]["games"]
-laggyGames = Array.new
-laggyGamesRaw.each do |g|
-    laggyGames << g["appid"]
+laggy_games_raw = pull_owned_games(@laggy)['response']['games']
+laggy_games = []
+laggy_games_raw.each do |g|
+  laggy_games << g['appid']
 end
 
 # get the intersection
-sharedGamesIds = greenGames & laggyGames
-sharedGames = Array.new
-sharedGamesIds.each do |g|
-  if appHash[g].nil?
-    next
-  else
-    sharedGames << appHash[g]
-  end
+shared_games_ids = green_games & laggy_games
+shared_games = []
+shared_games_ids.each do |g|
+  next if app_hash[g].nil?
+
+  shared_games << app_hash[g]
 end
-sharedGames.sort!
+shared_games.sort!
 
 # spit them out to screen
-sharedGames.each do |g|
-    puts g
+shared_games.each do |g|
+  puts g
 end
 
-puts sharedGames.length
+puts shared_games.length

--- a/config.ru
+++ b/config.ru
@@ -3,6 +3,6 @@ require 'bundler'
 
 Bundler.require
 
-require './myapp.rb'
+require './myapp'
 
 run MyApp

--- a/myapp.rb
+++ b/myapp.rb
@@ -4,9 +4,7 @@ require 'rubygems'
 require 'haml'
 require 'sinatra'
 
-require './steam_user.rb'
-
-#set :port, 8080
+require './steam_user'
 
 class MyApp < Sinatra::Base
   # load config file
@@ -49,11 +47,9 @@ class MyApp < Sinatra::Base
     # convert the games id list to game names
     shared_games = []
     shared_games_ids.each do |g|
-      if app_hash[g].nil?
-        next
-      else
-        shared_games << app_hash[g]
-      end
+      next if app_hash[g].nil?
+
+      shared_games << app_hash[g]
     end
     shared_games.sort!
 

--- a/myapp.rb
+++ b/myapp.rb
@@ -6,6 +6,8 @@ require 'sinatra'
 
 require './steam_user.rb'
 
+#set :port, 8080
+
 class MyApp < Sinatra::Base
   # load config file
   config = JSON.parse(File.read('config.json'))
@@ -47,7 +49,11 @@ class MyApp < Sinatra::Base
     # convert the games id list to game names
     shared_games = []
     shared_games_ids.each do |g|
-      shared_games << app_hash[g]
+      if app_hash[g].nil?
+        next
+      else
+        shared_games << app_hash[g]
+      end
     end
     shared_games.sort!
 


### PR DESCRIPTION
Code was failing when comparing users' games list. This was due to missing key-value pairs in the steam library hash for certain steam appid (valid on the user's game list but not found in the library hash). This created a nil value in the returned compared games array which caused the code to fail when it attempted to sort the list alphabetically. Added a "next if app_hash[g].nil?" line to the relevant loops to skip if the returned steam hash value (the game name) was invalid (nil). This does mean that a game which is found in both user lists is ignored, i.e. not returned by the code.

Also updated the code to comply with Rubocop standards, which involved changing function names from "get..." and variable names from camel case to snake case.